### PR TITLE
Fix Progress pip option

### DIFF
--- a/src/Manager/Cmd/Pip/PyPackage.Manager.Cmd.Pip.Install.pas
+++ b/src/Manager/Cmd/Pip/PyPackage.Manager.Cmd.Pip.Install.pas
@@ -267,7 +267,9 @@ end;
 function TPyPackageManagerCmdPipInstall.MakeInstallProgressBarCmd: TArray<string>;
 begin
   if FOpts.ProgressBar then
-    Result := TArray<string>.Create('--progress-bar');
+    Result := TArray<string>.Create('--progress-bar', 'on')
+  else
+    Result := TArray<string>.Create('--progress-bar', 'off');
 end;
 
 function TPyPackageManagerCmdPipInstall.MakeIntallPythonImplementationCmd: TArray<string>;


### PR DESCRIPTION
If a package has the Progress option selected the current code will cause PIP to error with a message saying it needs an option - this fixes this situation by adding the correct option to the PIP resulting command.

Note...
The default for PIP is to add the progress bar so this really is only effective for switching it off. Without this patch PIP will default to using a progress bar so this causes a progress bar NOT to be provided by default.

Possibly this option should be NoProgress and the on/off stings switched?