### PR TITLE
Correct OnlyBinary, add Verbose

### DIFF
--- a/src/Manager/Cmd/Pip/PyPackage.Manager.Cmd.Pip.Install.pas
+++ b/src/Manager/Cmd/Pip/PyPackage.Manager.Cmd.Pip.Install.pas
@@ -72,6 +72,7 @@ type
     function MakeInstallNoWarnConflictsCmd: TArray<string>; inline;
     function MakeInstallNoBinaryCmd: TArray<string>; inline;
     function MakeInstallOnlyBinaryCmd: TArray<string>; inline;
+    function MakeInstallVerboseCmd: TArray<string>; inline;
     function MakeInstallPreferBinaryCmd: TArray<string>; inline;
     function MakeInstallRequireHashesCmd: TArray<string>; inline;
     function MakeInstallProgressBarCmd: TArray<string>; inline;
@@ -236,8 +237,14 @@ end;
 
 function TPyPackageManagerCmdPipInstall.MakeInstallOnlyBinaryCmd: TArray<string>;
 begin
-  if FOpts.OnlyBinary then
-    Result := TArray<string>.Create('--only-binary');
+  if not FOpts.OnlyBinary.IsEmpty() then
+    Result := TArray<string>.Create('--only-binary', FOpts.OnlyBinary);
+end;
+
+function TPyPackageManagerCmdPipInstall.MakeInstallVerboseCmd: TArray<string>;
+begin
+  if FOpts.Verbose then
+    Result := TArray<string>.Create('-v');
 end;
 
 function TPyPackageManagerCmdPipInstall.MakeInstallPlatformCmd: TArray<string>;

--- a/src/Manager/Defs/Opts/Pip/PyPackage.Manager.Defs.Opts.Pip.Install.pas
+++ b/src/Manager/Defs/Opts/Pip/PyPackage.Manager.Defs.Opts.Pip.Install.pas
@@ -67,7 +67,8 @@ type
     FNoWarnConflicts: boolean;
     FNoBinary: boolean;
     FNoCompile: boolean;
-    FOnlyBinary: boolean;
+    FVerbose: boolean;
+    FOnlyBinary: String;
     FPreferBinary: boolean;
     FRequireHashes: boolean;
     FProgressBar: boolean;
@@ -110,7 +111,8 @@ type
     property NoWarnScriptLocation: boolean read FNoWarnScriptLocation write FNoWarnScriptLocation default false;
     property NoWarnConflicts: boolean read FNoWarnConflicts write FNoWarnConflicts default false;
     property NoBinary: boolean read FNoBinary write FNoBinary default false;
-    property OnlyBinary: boolean read FOnlyBinary write FOnlyBinary default false;
+    property Verbose: boolean read FVerbose write FVerbose default false;
+    property OnlyBinary: String read FOnlyBinary write FOnlyBinary;
     property PreferBinary: boolean read FPreferBinary write FPreferBinary default false;
     property RequireHashes: boolean read FRequireHashes write FRequireHashes default false;
     property ProgressBar: boolean read FProgressBar write FProgressBar default false;


### PR DESCRIPTION
OnlyBinary defined as boolean - proper options are strings e.g. ':all:'
Added a Verbose option to aid debugging (didn't help much tho - got the same output)

Note - we could do with a way to see the command being issued to make it easier to spot mistakes and/or try locally
Capture of the output from pip is also desirable - my phone says nothing but my ChromeBook is much more helpful